### PR TITLE
panic -> println && remove CreateTable from Copy

### DIFF
--- a/mysql/table_copier.go
+++ b/mysql/table_copier.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"github.com/rbwsam/ferry/util"
 	"log"
 	"strings"
+
+	"github.com/rbwsam/ferry/util"
 )
 
 type TableCopier struct {
@@ -26,7 +27,6 @@ func NewTableCopier(tableName string, srcCfg, destCfg *Config) *TableCopier {
 func (tc *TableCopier) Copy() {
 	log.Printf("Starting to copy table `%s`", tc.Name)
 
-	tc.CreateTable()
 	rows := tc.getRows()
 	defer rows.Close()
 

--- a/util/util.go
+++ b/util/util.go
@@ -6,6 +6,6 @@ import (
 
 func CheckError(error error) {
 	if error != nil {
-		log.Panic(error)
+		log.Println(error)
 	}
 }


### PR DESCRIPTION
this issue remove CreateTable from Copy function and use println instead of panic.

As a lib, the package should not panic, instead, it should raise an error.

Copy function should only do the Copy thing, some other operation should do outside of the Copy function.